### PR TITLE
Fix error handling when socket init is unsuccessful

### DIFF
--- a/pythonping/network.py
+++ b/pythonping/network.py
@@ -59,7 +59,7 @@ class Socket:
 
     def __del__(self):
         try:
-            if self.socket:
+            if hasattr(self, "socket") and self.socket:
                 self.socket.close()
         except AttributeError:
             raise AttributeError("Attribute error because of failed socket init. Make sure you have the root privilege."

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open('README.md', 'r') as file:
     long_description = file.read()
 
 setup(name='pythonping',
-      version='1.1.0',
+      version='1.0.10',
       description='A simple way to ping in Python',
       url='https://github.com/alessandromaggio/pythonping',
       author='Alessandro Maggio',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open('README.md', 'r') as file:
     long_description = file.read()
 
 setup(name='pythonping',
-      version='1.0.9',
+      version='1.1.0',
       description='A simple way to ping in Python',
       url='https://github.com/alessandromaggio/pythonping',
       author='Alessandro Maggio',


### PR DESCRIPTION
An attribute error was thrown when I was simulating packet loss. 