### PR TITLE
update to allow for safe multithreading and payload matching

### DIFF
--- a/test/test_ping.py
+++ b/test/test_ping.py
@@ -10,3 +10,6 @@ class PingCase(unittest.TestCase):
         # NOTE, this may be considered an e2e test
         self.assertEqual(len(ping('10.127.0.1', count=4, size=10)), 4,
                          'Sent 4 pings to localhost, but not received 4 responses')
+
+        self.assertEqual(ping('8.8.8.8', count=4, size=992, match=True).success(), False,
+                         'Sent 4 large pings to google DNS A, expected all to fail since they truncate large payloads')


### PR DESCRIPTION
-make pythonping thread safe
-Implement payload matching option between request and reply packets. Default pythonping behavior follows that of Windows which is by packet identifier only, Linux behavior counts a non equivalent payload in reply as fail, such as when pinging 8.8.8.8 with 1000 bytes and reply is truncated to only the first 74 of request payload with packet identifiers the same in request and reply.