### PR TITLE
Make Pythonping Thread-Safe

### DIFF
--- a/pythonping/__init__.py
+++ b/pythonping/__init__.py
@@ -42,7 +42,7 @@ def ping(target,
     :type verbose: bool
     :param out: Stream to which redirect the verbose output
     :type out: stream
-    :param match: Do payload matching between request and reply (default behaviour follows that of windows which is
+    :param match: Do payload matching between request and reply (default behaviour follows that of Windows which is
     by packet identifier only, Linux behaviour counts a non equivalent payload in reply as fail, such as when pinging
     8.8.8.8 with 1000 bytes and reply is truncated to only the first 74 of request payload with packet identifiers
     the same in request and reply)

--- a/pythonping/executor.py
+++ b/pythonping/executor.py
@@ -263,8 +263,6 @@ class Communicator:
 
     def listen_for(self, packet_id, timeout, payload_pattern=None):
         """Listens for a packet of a given id for a given timeout
-        (maintain pythonping legacy implementation (windows like) that didn't match payloads,
-        but allow for it to be set to be linux-like)
 
         :param packet_id: The ID of the packet to listen for, the same for request and response
         :type packet_id: int
@@ -282,7 +280,7 @@ class Communicator:
             # If we actually received something
             if raw_packet != b'':
                 response.unpack(raw_packet)
-                # to ensure legacy path (which was to not do payload inspection but only match packet identifiers),
+                # To allow Windows-like behaviour (no payload inspection, but only match packet identifiers),
                 # simply allow for it to be an always true in the legacy usage case
                 if payload_pattern is None:
                     payload_pattern = response.payload
@@ -308,7 +306,6 @@ class Communicator:
 
     def run(self, match_payloads=False):
         """Performs all the pings and stores the responses
-        (maintain legacy usage path of not matching payload but allow for it to be set)
 
         :param match_payloads: optional to set to True to make sure requests and replies have equivalent payloads
         :type match_payloads: bool"""

--- a/test/test_ping.py
+++ b/test/test_ping.py
@@ -11,5 +11,9 @@ class PingCase(unittest.TestCase):
         self.assertEqual(len(ping('10.127.0.1', count=4, size=10)), 4,
                          'Sent 4 pings to localhost, but not received 4 responses')
 
+        self.assertEqual(ping('8.8.8.8', count=4, size=992).success(), True,
+                         'Sent 4 large pings to google DNS A with payload match off, received all replies')
+
         self.assertEqual(ping('8.8.8.8', count=4, size=992, match=True).success(), False,
-                         'Sent 4 large pings to google DNS A, expected all to fail since they truncate large payloads')
+                         'Sent 4 large pings to google DNS A with payload match on,'
+                         + 'expected all to fail since they truncate large payloads')

--- a/test/test_ping.py
+++ b/test/test_ping.py
@@ -10,3 +10,6 @@ class PingCase(unittest.TestCase):
         # NOTE, this may be considered an e2e test
         self.assertEqual(len(ping('10.127.0.1', count=4, size=10)), 4,
                          'Sent 4 pings to localhost, but not received 4 responses')
+
+        self.assertEqual(ping('8.8.8.8', count=4, size=992, match=True).success(), False,
+                         'Sent 4 large pings to google DNS A, expected all to fail since they truncate large payloads')


### PR DESCRIPTION
Make python-ping thread-safe by checking the payloads of reply messages. In this way, multiple instance of pythonping can run in parallel without overlapping.