### PR TITLE
fix linux legacy match off case in threaded scenario broken, fix bug in match code on and some library documentation of payload

### DIFF
--- a/pythonping/executor.py
+++ b/pythonping/executor.py
@@ -252,14 +252,17 @@ class Communicator:
 
         :param packet_id: The ID to use for the packet
         :type packet_id: int
-        :param sequence_number: The seuqnce number to use for the packet
+        :param sequence_number: The sequence number to use for the packet
         :type sequence_number: int
         :param payload: The payload of the ICMP message
-        :type payload: bytes"""
-        self.socket.send(icmp.ICMP(
+        :type payload: Union[str, bytes]
+        :rtype: bytes"""
+        i = icmp.ICMP(
             icmp.Types.EchoRequest,
             payload=payload,
-            identifier=packet_id, sequence_number=sequence_number).packet)
+            identifier=packet_id, sequence_number=sequence_number)
+        self.socket.send(i.packet)
+        return i.payload
 
     def listen_for(self, packet_id, timeout, payload_pattern=None):
         """Listens for a packet of a given id for a given timeout
@@ -313,10 +316,10 @@ class Communicator:
         identifier = self.seed_id
         seq = 1
         for payload in self.provider:
-            self.send_ping(identifier, seq, payload)
+            payload_bytes_sent = self.send_ping(identifier, seq, payload)
             if not match_payloads:
                 self.responses.append(self.listen_for(identifier, self.timeout))
             else:
-                self.responses.append(self.listen_for(identifier, self.timeout, payload))
+                self.responses.append(self.listen_for(identifier, self.timeout, payload_bytes_sent))
 
             seq = self.increase_seq(seq)

--- a/pythonping/payload_provider.py
+++ b/pythonping/payload_provider.py
@@ -38,7 +38,7 @@ class Repeat(PayloadProvider):
         """Creates a provider of many identical payloads
 
         :param pattern: The existing payload
-        :type pattern: bytes
+        :type pattern: Union[str, bytes]
         :param count: How many payloads to generate
         :type count: int"""
         self.pattern = pattern
@@ -61,7 +61,7 @@ class Sweep(PayloadProvider):
         """Creates a provider of payloads of increasing size
 
         :param pattern: The existing payload, may be cut or replicated to fit the size
-        :type pattern: bytes
+        :type pattern: Union[str, bytes]
         :param start_size: The first payload size to start with, included
         :type start_size: int
         :param end_size: The payload size to end with, included


### PR DESCRIPTION
-update documentation to reflect Union of string and bytes as payload input internally
-correct bug in match code made from wrong assumptions based on previously misleading documentation