### PR TITLE
Fix ping type annotation

### DIFF
--- a/pythonping/__init__.py
+++ b/pythonping/__init__.py
@@ -24,7 +24,7 @@ def ping(target,
 
     :param target: The remote hostname or IP address to ping
     :type target: str
-    :param timeout: How long before considering each non-arrived reply permanently lost
+    :param timeout: Time in seconds before considering each non-arrived reply permanently lost.
     :type timeout: int, float
     :param count: How many times to attempt the ping
     :type count: int

--- a/pythonping/__init__.py
+++ b/pythonping/__init__.py
@@ -25,7 +25,7 @@ def ping(target,
     :param target: The remote hostname or IP address to ping
     :type target: str
     :param timeout: How long before considering each non-arrived reply permanently lost
-    :type timeout: int
+    :type timeout: int, float
     :param count: How many times to attempt the ping
     :type count: int
     :param size: Size of the entire packet to send


### PR DESCRIPTION
`ping()`'s timeout parameter is documented with type annotation. While using sub-second timeouts does work the type annotation allows only for `int`.

This pull request adds `float` as type annotation and adds the seconds as unit used to define the timeout to the documentation.