### PR TITLE
Calculate Packet Loss Statistics

### DIFF
--- a/pythonping/executor.py
+++ b/pythonping/executor.py
@@ -169,6 +169,10 @@ class ResponseList:
             result = False not in success_list
         return result
 
+    def packet_loss(self):
+        success_list = [resp.success for resp in self._responses]
+        return (success_list.count(False) / len(success_list)) * 100
+
     @property
     def rtt_min_ms(self):
         return represent_seconds_in_ms(self.rtt_min)

--- a/pythonping/executor.py
+++ b/pythonping/executor.py
@@ -148,6 +148,7 @@ class ResponseList:
         self.rtt_avg = 0
         self.rtt_min = 0
         self.rtt_max = 0
+        self.packets_lost = 0
         for response in initial_set:
             self.append(response)
 
@@ -169,9 +170,9 @@ class ResponseList:
             result = False not in success_list
         return result
 
+    @property
     def packet_loss(self):
-        success_list = [resp.success for resp in self._responses]
-        return (success_list.count(False) / len(success_list)) * 100
+        return self.packets_lost
 
     @property
     def rtt_min_ms(self):
@@ -201,6 +202,9 @@ class ResponseList:
                 self.rtt_max = value.time_elapsed
             if value.time_elapsed < self.rtt_min:
                 self.rtt_min = value.time_elapsed
+
+        self.packets_lost = self.packets_lost + (0 if value.success else 1 - self.packets_lost) / len(self)
+
         if self.verbose:
             print(value, file=self.output)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open('README.md', 'r') as file:
     long_description = file.read()
 
 setup(name='pythonping',
-      version='1.0.13',
+      version='1.0.14',
       description='A simple way to ping in Python',
       url='https://github.com/alessandromaggio/pythonping',
       author='Alessandro Maggio',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open('README.md', 'r') as file:
     long_description = file.read()
 
 setup(name='pythonping',
-      version='1.0.11',
+      version='1.0.12',
       description='A simple way to ping in Python',
       url='https://github.com/alessandromaggio/pythonping',
       author='Alessandro Maggio',

--- a/test/test_executor.py
+++ b/test/test_executor.py
@@ -247,6 +247,47 @@ class ResponseListTestCase(unittest.TestCase):
             'Unable to calculate success on all with half responses successful'
         )
 
+    def test_no_packets_lost(self):
+        rs = executor.ResponseList([
+            SuccessfulResponseMock(None, 1),
+            SuccessfulResponseMock(None, 1),
+            SuccessfulResponseMock(None, 1),
+            SuccessfulResponseMock(None, 1)
+        ])
+
+        self.assertEqual(
+            rs.packet_loss, 
+            0.0, 
+            "Unable to calculate packet loss correctly when all resposes successful"
+        )
+
+    def test_all_packets_lost(self):
+        rs = executor.ResponseList([
+            FailingResponseMock(None, 1),
+            FailingResponseMock(None, 1),
+            FailingResponseMock(None, 1),
+            FailingResponseMock(None, 1)
+        ])
+
+        self.assertEqual(
+            rs.packet_loss, 
+            1.0, 
+            "Unable to calculate packet loss correctly when all resposes failed"
+        )
+
+    def test_some_packets_lost(self):
+        rs = executor.ResponseList([
+            SuccessfulResponseMock(None, 1),
+            SuccessfulResponseMock(None, 1),
+            FailingResponseMock(None, 1),
+            FailingResponseMock(None, 1)
+        ])
+
+        self.assertEqual(
+            rs.packet_loss, 
+            0.5, 
+            "Unable to calculate packet loss correctly when some of the responses failed"
+        )
 
 class CommunicatorTestCase(unittest.TestCase):
     """Tests for Communicator"""


### PR DESCRIPTION
Per discussion on #58 this PR adds:
* A method on the `ResponseList` object that returns the percent of packets lost where 0% packets lost = a return value of `0.0` and 100% packet loss = a return value of `1.0`. The number is calculated as a running average so no additional computation is done when the method is called.

I didn't add this stat to the `__repr__` method, but would be happy to if you think it would be useful!

Thanks for reviewing in advance!