### PR TITLE
feat: Enable ping sweep without forcing size to None

### DIFF
--- a/pythonping/__init__.py
+++ b/pythonping/__init__.py
@@ -49,14 +49,14 @@ def ping(target,
     :return: List with the result of each ping
     :rtype: executor.ResponseList"""
     provider = payload_provider.Repeat(b'', 0)
-    if size and size > 0:
-        if not payload:
-            payload = random_text(size)
-        provider = payload_provider.Repeat(payload, count)
-    elif sweep_start and sweep_end and sweep_end >= sweep_start:
+    if sweep_start and sweep_end and sweep_end >= sweep_start:
         if not payload:
             payload = random_text(sweep_start)
         provider = payload_provider.Sweep(payload, sweep_start, sweep_end)
+    elif size and size > 0:
+        if not payload:
+            payload = random_text(size)
+        provider = payload_provider.Repeat(payload, count)
     options = ()
     if df:
         options = network.Socket.DONT_FRAGMENT

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open('README.md', 'r') as file:
     long_description = file.read()
 
 setup(name='pythonping',
-      version='1.0.15',
+      version='1.0.16',
       description='A simple way to ping in Python',
       url='https://github.com/alessandromaggio/pythonping',
       author='Alessandro Maggio',


### PR DESCRIPTION
In the ping function, sweep settings take precedence over size as they default to `None`. Hence, whenever they are set correctly size is ignored. Previously, even setting them correctly would not work unless size was manually set to `None`.