### PR TITLE
Fix Packet loss calculation and add new test

### DIFF
--- a/pythonping/executor.py
+++ b/pythonping/executor.py
@@ -203,7 +203,7 @@ class ResponseList:
             if value.time_elapsed < self.rtt_min:
                 self.rtt_min = value.time_elapsed
 
-        self.packets_lost = self.packets_lost + (0 if value.success else 1 - self.packets_lost) / len(self)
+        self.packets_lost = self.packets_lost + ((0 if value.success else 1) - self.packets_lost) / len(self)
 
         if self.verbose:
             print(value, file=self.output)

--- a/test/test_executor.py
+++ b/test/test_executor.py
@@ -289,6 +289,20 @@ class ResponseListTestCase(unittest.TestCase):
             "Unable to calculate packet loss correctly when some of the responses failed"
         )
 
+    def test_some_packets_lost_mixed(self):
+        rs = executor.ResponseList([
+            FailingResponseMock(None, 1),
+            SuccessfulResponseMock(None, 1),
+            FailingResponseMock(None, 1),
+            SuccessfulResponseMock(None, 1),
+        ])
+
+        self.assertEqual(
+            rs.packet_loss,
+            0.5,
+            "Unable to calculate packet loss correctly when failing responses are mixed with successful responses"
+        )
+
 
 class CommunicatorTestCase(unittest.TestCase):
     """Tests for Communicator"""


### PR DESCRIPTION
When failed requests were mixed with successful ones, the calculation was wrong due to missing parentheses