### PR TITLE
Ignore lost packets in the calculation of statistics

### DIFF
--- a/pythonping/executor.py
+++ b/pythonping/executor.py
@@ -191,17 +191,19 @@ class ResponseList:
 
     def append(self, value):
         self._responses.append(value)
-        if len(self) == 1:
-            self.rtt_avg = value.time_elapsed
-            self.rtt_max = value.time_elapsed
-            self.rtt_min = value.time_elapsed
-        else:
-            # Calculate the total of time, add the new value and divide for the new number
-            self.rtt_avg = ((self.rtt_avg * (len(self)-1)) + value.time_elapsed) / len(self)
-            if value.time_elapsed > self.rtt_max:
+        if value.success:
+            success_responses = len(self) - self.packets_lost * (len(self) - 1)
+            if success_responses == 1:
+                self.rtt_avg = value.time_elapsed
                 self.rtt_max = value.time_elapsed
-            if value.time_elapsed < self.rtt_min:
                 self.rtt_min = value.time_elapsed
+            else:
+                # Calculate the total of time, add the new value and divide for the new number
+                self.rtt_avg = ((self.rtt_avg * (success_responses - 1)) + value.time_elapsed) / success_responses
+                if value.time_elapsed > self.rtt_max:
+                    self.rtt_max = value.time_elapsed
+                if value.time_elapsed < self.rtt_min:
+                    self.rtt_min = value.time_elapsed
 
         self.packets_lost = self.packets_lost + (0 if value.success else 1 - self.packets_lost) / len(self)
 


### PR DESCRIPTION
If all packets are lost all statistics will be 0

I've added some tests here: https://github.com/HandyMenny/pythonping/commit/a2ecdf2fbef8ffe684871d387c0c987ed9c93010
Besides the fact that they're too messy, without #66 they will fail

If you don't completely agree with these changes you might as well make it optional, but I think 99% of users don't want TIMEOUT to be considered in the stats.
You might think of a special value when there is 100% lost packets, but in my opinion 0 is fine 