### PR TITLE
Add Github Actions Python Test

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -1,0 +1,18 @@
+name: Python test
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Test with pytest
+      run: |
+        sudo pip install pytest pytest-cov
+        sudo -E pytest --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -8,4 +8,4 @@ class UtilsTestCase(unittest.TestCase):
     def test_raise_explicative_error_on_name_resolution_failure(self):
         """Test a runtime error is generated if the name cannot be resolved"""
         with self.assertRaises(RuntimeError):
-            Socket('cant.resolve.this.address.localhost', 'ip')
+            Socket('invalid', 'raw')

--- a/test/test_ping.py
+++ b/test/test_ping.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 from pythonping import ping
 
 
@@ -11,9 +12,11 @@ class PingCase(unittest.TestCase):
         self.assertEqual(len(ping('10.127.0.1', count=4, size=10)), 4,
                          'Sent 4 pings to localhost, but not received 4 responses')
 
-        self.assertEqual(ping('8.8.8.8', count=4, size=992).success(), True,
-                         'Sent 4 large pings to google DNS A with payload match off, received all replies')
+        # Github Actions does not support ICMP
+        if os.getenv("GITHUB_ACTIONS") is None:
+            self.assertEqual(ping('8.8.8.8', count=4, size=992).success(), True,
+                             'Sent 4 large pings to google DNS A with payload match off, received all replies')
 
-        self.assertEqual(ping('8.8.8.8', count=4, size=992, match=True).success(), False,
-                         'Sent 4 large pings to google DNS A with payload match on,'
-                         + 'expected all to fail since they truncate large payloads')
+            self.assertEqual(ping('8.8.8.8', count=4, size=992, match=True).success(), False,
+                             'Sent 4 large pings to google DNS A with payload match on,'
+                             + 'expected all to fail since they truncate large payloads')


### PR DESCRIPTION
invalid network dns changed to RFC suggested invalid to avoid resolution of localhost domain
Active ping tests avoided on Github Actions since it does not support ICMP