### PR TITLE
fix(icmp.py): ICMP header format string

### DIFF
--- a/pythonping/icmp.py
+++ b/pythonping/icmp.py
@@ -171,7 +171,7 @@ class ICMP:
         :return: The packed header
         :rtype: bytes"""
         # TODO implement sequence number
-        return struct.pack("bbHHh",
+        return struct.pack("BBHHH",
                            self.message_type,
                            self.message_code,
                            check,
@@ -220,5 +220,5 @@ class ICMP:
             self.message_code, \
             self.received_checksum, \
             self.id, \
-            self.sequence_number = struct.unpack("bbHHh", raw[20:28])
+            self.sequence_number = struct.unpack("BBHHH", raw[20:28])
         self.payload = raw[28:]


### PR DESCRIPTION
All values in the struct should be unsigned.

Refering to [the docs](https://docs.python.org/3/library/struct.html#format-characters) it appears the large count limitation was caused by incorrectly using signed formats for the ICMP header packing/unpacking. 

This now allows for `count` to be set to  numbers greater than 16-bits when calling `ping()`. The effect on the sequence number in the ICMP header is that it will wrap around after 0xFFFFFFFF (65536), and continue to increment. (Confirmed in Wireshark on Windows 10, python3.10.5).