### PR TITLE
fix Windows DF option

### DIFF
--- a/pythonping/__init__.py
+++ b/pythonping/__init__.py
@@ -66,7 +66,10 @@ def ping(target,
         provider = payload_provider.Repeat(payload, count)
     options = ()
     if df:
-        options = network.Socket.DONT_FRAGMENT
+        if sys.platform.startswith('win'):
+            options = network.Socket.DONT_FRAGMENT_WIN
+        else:
+            options = network.Socket.DONT_FRAGMENT
 
     # Fix to allow for pythonping multithreaded usage;
     # no need to protect this loop as no one will ever surpass 0xFFFF amount of threads

--- a/pythonping/network.py
+++ b/pythonping/network.py
@@ -5,6 +5,7 @@ import time
 
 class Socket:
     DONT_FRAGMENT = (socket.SOL_IP, 10, 1)           # Option value for raw socket
+    DONT_FRAGMENT_WIN = (socket.IPPROTO_IP, 14, 1)   # use IP_DONTFRAGMENT 14 from ws2ipdef.h
     PROTO_LOOKUP = {"icmp": socket.IPPROTO_ICMP, "tcp": socket.IPPROTO_TCP, "udp": socket.IPPROTO_UDP,
                     "ip": socket.IPPROTO_IP, "raw": socket.IPPROTO_RAW}
 


### PR DESCRIPTION
using IP_DONTFRAGMENT from https://github.com/MicrosoftDocs/win32/blob/docs/desktop-src/WinSock/ipproto-ip-socket-options.md

> Indicates that data should not be fragmented regardless of the local MTU. Valid only for message oriented protocols. Microsoft TCP/IP providers respect this option for UDP and ICMP.

with value from here https://github.com/tpn/winsdk-10/blob/master/Include/10.0.14393.0/shared/ws2ipdef.h

> #define IP_DONTFRAGMENT           14 // Don't fragment IP datagrams.